### PR TITLE
Extend travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - ruby-2.3.3
 env:
   - PUPPET_VERSION='~> 3.7.0'
   - PUPPET_VERSION='~> 3.8.0'
@@ -14,4 +15,8 @@ matrix:
     - rvm: 2.2
       env: PUPPET_VERSION='~> 3.7.0'
     - rvm: 2.2
+      env: PUPPET_VERSION='~> 3.8.0'
+    - rvm: ruby-2.3
+      env: PUPPET_VERSION='~> 3.7.0'
+    - rvm: ruby-2.3
       env: PUPPET_VERSION='~> 3.8.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
   - PUPPET_VERSION='~> 3.7.0'
   - PUPPET_VERSION='~> 3.8.0'
   - PUPPET_VERSION='~> 4.5.0'
+  - PUPPET_VERSION='~> 4.6.0'
+  - PUPPET_VERSION='~> 4.7.0'
+  - PUPPET_VERSION='~> 4.8.0'
 matrix:
   exclude:
     - rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       env: PUPPET_VERSION='~> 3.7.0'
     - rvm: 2.2
       env: PUPPET_VERSION='~> 3.8.0'
-    - rvm: ruby-2.3
+    - rvm: ruby-2.3.3
       env: PUPPET_VERSION='~> 3.7.0'
-    - rvm: ruby-2.3
+    - rvm: ruby-2.3.3
       env: PUPPET_VERSION='~> 3.8.0'


### PR DESCRIPTION
Add recent Ruby and recent Puppet versions

That's 20 builds, maybe it's a bit too much.  Maybe we can remove older Puppet 4.x versions.  What do you think ?