### PR TITLE
Add support for custom environment variables

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,6 @@
 define bundle::install (
   $deployment = true,
+  $environment = [],
   $path = undef,
   $user = 'root',
   $with = [],
@@ -7,6 +8,8 @@ define bundle::install (
   $timeout = 300,
 ) {
   require ::bundle
+
+  validate_array($environment)
 
   if $deployment {
     $deployment_arg = '--deployment'
@@ -35,6 +38,7 @@ define bundle::install (
   exec { "${user}@${::hostname} ${name}% ${::bundle::command} install":
     command     => join(reject([$::bundle::command, 'install', $deployment_arg, $path_arg, $with_arg, $without_arg], '^$'), ' '),
     cwd         => $name,
+    environment => $environment,
     refreshonly => true,
     user        => $user,
     timeout     => $timeout,

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -7,12 +7,14 @@ describe 'bundle::install' do
 
   let(:params) do
     {
+      environment: custom_environment,
       path: path,
       user: 'deploy',
       with: with,
       without: without
     }
   end
+  let(:custom_environment) { [] }
   let(:path) { :undef }
   let(:with) { 'single' }
   let(:without) { %w(one two three) }
@@ -21,8 +23,19 @@ describe 'bundle::install' do
   it do
     is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install').with(
       command: '/usr/bin/bundle install --deployment --with single --without one two three',
+      environment: [],
       user: 'deploy'
     )
+  end
+
+  context 'custom environment' do
+    let(:custom_environment) { ['BUNDLER_GEMFILE=Gemfile.aarch64'] }
+
+    it do
+      is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install').with(
+        environment: ['BUNDLER_GEMFILE=Gemfile.aarch64'],
+      )
+    end
   end
 
   context 'custom path' do


### PR DESCRIPTION
Please note that naming a variable 'environment' makes RSpec feel bad,
hence the funny variable name.