### PR TITLE
Rely on `bundle check` to see if a bundle is out-of-date

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,12 +35,14 @@ define bundle::install (
     $without_arg = join(['--without', join(any2array($without), ' ')], ' ')
   }
 
-  exec { "${user}@${::hostname} ${name}% ${::bundle::command} install":
-    command     => join(reject([$::bundle::command, 'install', $deployment_arg, $path_arg, $with_arg, $without_arg], '^$'), ' '),
+  $command = join(reject([$::bundle::command, 'install', $deployment_arg, $path_arg, $with_arg, $without_arg], '^$'), ' ')
+
+  exec { "${user}@${::hostname} ${name}% ${command}":
+    command     => $command,
     cwd         => $name,
     environment => $environment,
-    refreshonly => true,
-    user        => $user,
     timeout     => $timeout,
+    unless      => "${::bundle::command} check",
+    user        => $user,
   }
 }

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -21,7 +21,7 @@ describe 'bundle::install' do
 
   it { is_expected.to compile }
   it do
-    is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install').with(
+    is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install --deployment --with single --without one two three').with(
       command: '/usr/bin/bundle install --deployment --with single --without one two three',
       environment: [],
       user: 'deploy'
@@ -32,7 +32,7 @@ describe 'bundle::install' do
     let(:custom_environment) { ['BUNDLER_GEMFILE=Gemfile.aarch64'] }
 
     it do
-      is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install').with(
+      is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install --deployment --with single --without one two three').with(
         environment: ['BUNDLER_GEMFILE=Gemfile.aarch64'],
       )
     end
@@ -42,7 +42,7 @@ describe 'bundle::install' do
     let(:path) { 'vendor/bundle' }
 
     it do
-      is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install').with(
+      is_expected.to contain_exec('deploy@hostname /path/to/bundle% /usr/bin/bundle install --deployment --path vendor/bundle --with single --without one two three').with(
         command: '/usr/bin/bundle install --deployment --path vendor/bundle --with single --without one two three',
         user: 'deploy'
       )


### PR DESCRIPTION
Do not require an explicit notification but rather check that the
current bundle is outdated to trigger a bundle installation.

While here, include all arguments in resource title, and sort
attributes.