### PR TITLE
Make travis-ci happy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.1
   - 2.2
   - ruby-2.3.3
+before_install:
+  - gem update --system
 env:
   - PUPPET_VERSION='~> 3.7.0'
   - PUPPET_VERSION='~> 3.8.0'


### PR DESCRIPTION
The version of bundler (0.14) used on travis-ci breaks the install of
rainbow which is a required dependency.

Force an update on travis in order to work-around this problem.