### PR TITLE
Switch form Puppet to OpenVox

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,4 @@
+---
 fixtures:
   repositories:
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-  symlinks:
-    bundle: "#{source_dir}"
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   puppet:
     name: Puppet

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,10 @@ name: "Pull Request Labeler"
 on:
   pull_request_target: {}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release

--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,5 @@
----
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '10.1.0'
+--format documentation
+--color

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,5 +1,4 @@
----
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '10.1.0'
+--format progress

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 9.0',   :require => false
+  gem 'voxpupuli-test', '~> 11.0',  :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 5.0',  :require => false
@@ -16,17 +16,15 @@ group :development do
 end
 
 group :system_tests do
-  gem 'voxpupuli-acceptance', '~> 3.5',  :require => false
+  gem 'voxpupuli-acceptance', '~> 4.0',  :require => false
 end
 
 group :release do
-  gem 'voxpupuli-release', '~> 3.0',  :require => false
+  gem 'voxpupuli-release', '~> 4.0',  :require => false
 end
 
 gem 'rake', :require => false
-gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_GEM_VERSION'] || [">= 7.24", "< 9"]
-gem 'puppet', puppetversion, :require => false, :groups => [:test]
+gem 'openvox', ENV.fetch('OPENVOX_GEM_VERSION', [">= 7", "< 9"]), :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,30 +1,22 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-# Attempt to load voxpupuli-test (which pulls in puppetlabs_spec_helper),
-# otherwise attempt to load it directly.
 begin
   require 'voxpupuli/test/rake'
 rescue LoadError
-  begin
-    require 'puppetlabs_spec_helper/rake_tasks'
-  rescue LoadError
-  end
+  # only available if gem group test is installed
 end
 
-# load optional tasks for acceptance
-# only available if gem group releases is installed
 begin
   require 'voxpupuli/acceptance/rake'
 rescue LoadError
+  # only available if gem group acceptance is installed
 end
 
-# load optional tasks for releases
-# only available if gem group releases is installed
 begin
   require 'voxpupuli/release/rake_tasks'
 rescue LoadError
-  # voxpupuli-release not present
+  # only available if gem group releases is installed
 else
   GCGConfig.user = 'opus-codium'
   GCGConfig.project = 'puppet-bundle'

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
       "operatingsystemrelease": [
         "10",
         "11",
-	"12"
+        "12"
       ]
     },
     {
@@ -34,8 +34,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.19.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
Now that Perforce has killed Puppet, we need to switch to OpenVox to run tests. As we cannot run tests with Puppet Core, as it makes no sense to continue testing against legacy Open Source Puppet, and as Puppet 7 has reached EOL, we can drop support for Puppet completely.  People will still be able to send PR to fix issue if they find some with Puppet Core, but we cannot support this setup, and we encourage users to avoid this situation.
